### PR TITLE
S3 PreSignurl 로직 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.26"
+    "typeorm": "^0.3.26",
+    "aws-sdk": "^2.1628.0",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -45,6 +47,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
+    "@types/uuid": "^9.0.8",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { RouterModule } from '@nestjs/core';
 import { SeoulMeariModule } from './seoulmeari/seoulmeari.module';
 import { SeoulMeariManageModule } from './seoulmeari-manage/seoulmeari-manage.module';
 import { DatabaseModule } from './common/database/database.module';
+import { S3Module } from './s3/s3.module';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 
@@ -18,6 +19,7 @@ import { AppController } from './app.controller';
     SeoulMeariModule,
     SeoulMeariManageModule,
     DatabaseModule,
+    S3Module,
     RouterModule.register([
       { path: 'api', module: SeoulMeariModule },
       { path: 'manage', module: SeoulMeariManageModule },

--- a/src/s3/dto/create-analysis-urls.dto.ts
+++ b/src/s3/dto/create-analysis-urls.dto.ts
@@ -1,0 +1,10 @@
+import { Type } from 'class-transformer';
+import { IsArray, ValidateNested } from 'class-validator';
+import { FileUploadRequestDto } from './file-upload-request.dto';
+
+export class CreateAnalysisUrlsDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => FileUploadRequestDto)
+  files: FileUploadRequestDto[];
+}

--- a/src/s3/dto/create-echo-url.dto.ts
+++ b/src/s3/dto/create-echo-url.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateEchoUrlDto {
+  @IsString()
+  @IsNotEmpty()
+  filename: string;
+
+  @IsString()
+  @IsNotEmpty()
+  contentType: string;
+}

--- a/src/s3/dto/file-upload-request.dto.ts
+++ b/src/s3/dto/file-upload-request.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class FileUploadRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  originalFilename: string;
+
+  @IsString()
+  @IsNotEmpty()
+  objectName: string;
+}

--- a/src/s3/s3.controller.ts
+++ b/src/s3/s3.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { S3Service } from './s3.service';
+import { CreateAnalysisUrlsDto } from './dto/create-analysis-urls.dto';
+import { CreateEchoUrlDto } from './dto/create-echo-url.dto';
+
+@Controller('s3')
+export class S3Controller {
+  constructor(private readonly s3Service: S3Service) {}
+
+  @Post('presigned-urls/analysis')
+  async createPresignedUrlsForAnalysis(
+    @Body() createAnalysisUrlsDto: CreateAnalysisUrlsDto,
+  ) {
+    return this.s3Service.createPresignedUrlsForAnalysis(
+      createAnalysisUrlsDto.files,
+    );
+  }
+
+  @Post('presigned-url/echo')
+  async createPresignedUrlForEcho(@Body() createEchoUrlDto: CreateEchoUrlDto) {
+    const { filename, contentType } = createEchoUrlDto;
+    return this.s3Service.createPresignedUrlForEcho(filename, contentType);
+  }
+}

--- a/src/s3/s3.module.ts
+++ b/src/s3/s3.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { S3Controller } from './s3.controller';
+import { S3Service } from './s3.service';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [S3Controller],
+  providers: [S3Service],
+  exports: [S3Service],
+})
+export class S3Module {}

--- a/src/s3/s3.service.ts
+++ b/src/s3/s3.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as AWS from 'aws-sdk';
+import { v4 as uuidv4 } from 'uuid';
+import * as path from 'path';
+import { FileUploadRequestDto } from './dto/file-upload-request.dto';
+
+@Injectable()
+export class S3Service {
+  private readonly s3: AWS.S3;
+  private readonly bucketName: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.s3 = new AWS.S3({
+      region: this.configService.get<string>('AWS_REGION'),
+    });
+    this.bucketName = this.configService.get<string>('S3_BUCKET_NAME');
+  }
+
+  /**
+   * 분석용 이미지들의 Presigned URL을 병렬로 생성합니다.
+   */
+  async createPresignedUrlsForAnalysis(files: FileUploadRequestDto[]) {
+    const promises = files.map((file) => {
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = String(now.getMonth() + 1).padStart(2, '0');
+      const day = String(now.getDate()).padStart(2, '0');
+      const hours = String(now.getHours()).padStart(2, '0');
+      const minutes = String(now.getMinutes()).padStart(2, '0');
+      const seconds = String(now.getSeconds()).padStart(2, '0');
+
+      const dateFolderPath = `${year}${month}${day}`;
+      const timeFileNamePart = `${hours}${minutes}${seconds}`;
+      const objectName = file.objectName;
+      const uniqueId = uuidv4().substring(0, 8);
+      const extension = path.extname(file.originalFilename);
+
+      const key = `upload_image/${dateFolderPath}/${timeFileNamePart}_${objectName}_${uniqueId}${extension}`;
+
+      const params = {
+        Bucket: this.bucketName,
+        Key: key,
+        Expires: 300, // 5분
+      };
+      return this.s3
+        .getSignedUrlPromise('putObject', params)
+        .then((url) => ({ url, key }));
+    });
+
+    return Promise.all(promises);
+  }
+
+  /**
+   * 메아리용 단일 이미지의 Presigned URL을 생성합니다.
+   */
+  async createPresignedUrlForEcho(filename: string, contentType: string) {
+    const uniqueId = uuidv4();
+    const extension = path.extname(filename);
+    const baseFilename = path.basename(filename, extension);
+    const key = `echo_images/${uniqueId}-${baseFilename}${extension}`;
+
+    const params = {
+      Bucket: this.bucketName,
+      Key: key,
+      ContentType: contentType,
+      Expires: 300, // 5분
+    };
+
+    const url = await this.s3.getSignedUrlPromise('putObject', params);
+    return { url, key };
+  }
+
+  /**
+   * (관리자용) 파일 조회를 위한 Presigned URL을 생성합니다.
+   */
+  async getPresignedUrlForView(key: string): Promise<string> {
+    const params = {
+      Bucket: this.bucketName,
+      Key: key,
+      Expires: 3600, // 1시간
+    };
+    return this.s3.getSignedUrlPromise('getObject', params);
+  }
+}

--- a/src/seoulmeari/echo/dto/create-echo.dto.ts
+++ b/src/seoulmeari/echo/dto/create-echo.dto.ts
@@ -3,6 +3,7 @@ import { LocationDto } from './location.dto';
 import {
   IsNotEmpty,
   IsNumber,
+  IsOptional,
   IsString,
   ValidateNested,
 } from 'class-validator';
@@ -19,6 +20,10 @@ export class CreateEchoDto {
   @IsString()
   @IsNotEmpty()
   content: string;
+
+  @IsString()
+  @IsOptional()
+  imageKey?: string;
 
   @IsString()
   @IsNotEmpty()

--- a/src/seoulmeari/echo/echo.entity.ts
+++ b/src/seoulmeari/echo/echo.entity.ts
@@ -19,6 +19,9 @@ export class Echo {
   @Column({ type: 'text' })
   content: string;
 
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  imageKey: string;
+
   @CreateDateColumn({ name: 'created_at', type: 'varchar', length: 100 })
   createdAt: string;
 


### PR DESCRIPTION
## 📌 작업 내용
- S3 pre-SignURL 로직 구현

### S3 구조

```sql
upload_image(폴더)
ㄴ 년월일(폴더)
     ㄴ시간분초/객체이름
```

### 구현

- **(분석용)**: 여러 장의 사진(`파일명`, `객체이름`) 정보를 한 번에 받아, 각각에 대한 업로드 URL과 `Key`를 배열로 반환한다.
- **(메아리용)**: 한 장의 사진(`파일명`) 정보를 받아, 업로드 URL과 `Key`를 단일 객체로 반환한다.

---

### **`S3` 모듈**

`src/s3` 분석, 메아리 모두 처리할 수 있는 S3 관련 파일을 생성하고 구현

- **`s3.service.ts` (핵심 로직)**:
    - **`createPresignedUrlsForAnalysis(files)` 메소드**:
        - **입력**: 파일 정보(`originalFilename`, `objectName`) 객체의 배열
        - **동작**: `Promise.all`을 사용해 여러 URL을 **병렬**로 생성
        - **`Key` 생성 규칙**: `upload_image/YYYYMMDD/HHmmss_객체이름_고유ID.확장자`
        - **출력**: `{ url, key }` 객체의 배열
    - **`createPresignedUrlForEcho(filename)` 메소드**:
        - **입력**: 단일 파일명(`filename`), `contentType`
        - **동작**: 단일 URL을 생성
        - **`Key` 생성 규칙**: `echo_images/고유ID-파일명.확장자`
        - **출력**: `{ url, key }` 단일 객체
    - **`getPresignedUrlForView(key)` 메소드**:
        - (구현은 해두지만 `Echo` 모듈에서는 사용하지 않음) 나중에 관리자 모듈에서 사용할 수 있도록, `key`를 받아 조회용 URL을 생성하는 기능을 포함
- **DTO 파일들 (`src/s3/dto/`)**:
    - `file-upload-request.dto.ts`: 분석용 요청 시 배열에 담길 개별 파일 정보(`originalFilename`, `objectName`)를 정의
    - `create-analysis-urls.dto.ts`: 위 DTO의 배열을 받는 DTO를 정의
    - `create-echo-url.dto.ts`: 메아리용 단일 파일 정보(`filename`, `contentType`)를 받는 DTO를 정의
- **`s3.controller.ts` (API 창구)**:
    - **`POST /s3/presigned-urls/analysis`**: 분석용 대량 업로드 요청을 처리하고, `createPresignedUrlsForAnalysis`를 호출한다
    - **`POST /s3/presigned-url/echo`**: 메아리용 단일 업로드 요청을 처리하고, `createPresignedUrlForEcho`를 호출한다
- **`s3.module.ts`**:
    - 위에서 만든 컨트롤러와 서비스를 등록하고, `S3Service`를 `exports`로 공개한다

### **`app.module.ts` - `S3` 모듈 등록**

- `app.module.ts`의 `imports` 배열에 `S3Module`을 추가하여, `/s3/...` 경로의 API들을 독립적으로 수행할 수 있도록 추가.

### **`Echo` 모듈 - `imageKey` 저장 기능 추가**

`Echo` 모듈은 S3와 직접 통신하지 않고, 클라이언트가 전달해주는 `imageKey`를 저장하는 역할

- **`echo.entity.ts` 수정**:
    - `imageKey: string` 컬럼을 추가. (`nullable: true` 옵션 포함)
- **`create-echo.dto.ts` 수정**:
    - 클라이언트가 `imageKey`를 보낼 수 있도록 `imageKey?: string` 필드를 추가 (`IsOptional` 데코레이터 사용)
- **`echo-response.dto.ts` 수정**:
    - `imageUrl` 필드는 추가하지 않는다**.** (필요하다면 `imageKey`는 응답에 포함시킬 수 있다.)
- **`echo.service.ts`의 `create` 메소드 수정**:
    - `S3Service`를 **주입받지 않는다.**
    - 클라이언트로부터 받은 `CreateEchoDto`에 `imageKey`가 포함되어 있다면, 다른 정보와 함께 DB에 그대로 저장