### PR TITLE
대시보드 표시 및 그래프 계산 API

### DIFF
--- a/src/seoulmeari-manage/dashboard/dashboard.controller.ts
+++ b/src/seoulmeari-manage/dashboard/dashboard.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get } from '@nestjs/common';
+import { DashboardService } from './dashboard.service';
+
+@Controller('dashboard')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get('summary')
+  async getSummary() {
+    return this.dashboardService.getSummary();
+  }
+
+  @Get('ai-summary')
+  async getAiDiagnosisSummary() {
+    return this.dashboardService.getAiDiagnosisSummary();
+  }
+
+  @Get('weekly-diagnoses')
+  async getWeeklyDiagnoses() {
+    return this.dashboardService.getWeeklyDiagnoses();
+  }
+
+  @Get('tag-distribution')
+  async getTagDistribution() {
+    return this.dashboardService.getTagDistribution();
+  }
+
+  @Get('hourly-complaint-distribution')
+  async getHourlyComplaintDistribution() {
+    return this.dashboardService.getHourlyComplaintDistribution();
+  }
+}

--- a/src/seoulmeari-manage/dashboard/dashboard.module.ts
+++ b/src/seoulmeari-manage/dashboard/dashboard.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Complaint } from 'src/seoulmeari/complaints/entities/complaint.entity';
+import { Echo } from 'src/seoulmeari/echo/entities/echo.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Complaint, Echo])],
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/src/seoulmeari-manage/dashboard/dashboard.service.ts
+++ b/src/seoulmeari-manage/dashboard/dashboard.service.ts
@@ -1,0 +1,183 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Complaint } from 'src/seoulmeari/complaints/entities/complaint.entity';
+import { Echo } from 'src/seoulmeari/echo/entities/echo.entity';
+import { Between, Repository, MoreThan } from 'typeorm';
+
+@Injectable()
+export class DashboardService {
+  constructor(
+    @InjectRepository(Complaint)
+    private readonly complaintRepository: Repository<Complaint>,
+    @InjectRepository(Echo)
+    private readonly echoRepository: Repository<Echo>,
+  ) {}
+
+  async getSummary() {
+    // 1. 기간 설정
+    const today = new Date();
+    const sevenDaysAgo = new Date(today);
+    sevenDaysAgo.setDate(today.getDate() - 7);
+    const fourteenDaysAgo = new Date(today);
+    fourteenDaysAgo.setDate(today.getDate() - 14);
+
+    // 2. 데이터 조회
+    // 지난 7일간의 데이터
+    const recentComplaints = await this.complaintRepository.find({
+      where: { timestamp: Between(sevenDaysAgo, today) },
+    });
+
+    // 그 이전 7일간의 데이터
+    const previousComplaints = await this.complaintRepository.find({
+      where: { timestamp: Between(fourteenDaysAgo, sevenDaysAgo) },
+    });
+
+    const totalEchos = await this.echoRepository.count();
+
+    // 3. 핵심 지표 계산
+    // 총 진단 건수
+    const recentTotalCount = recentComplaints.length;
+    const previousTotalCount = previousComplaints.length;
+    const totalCountChange = previousTotalCount > 0 
+      ? ((recentTotalCount - previousTotalCount) / previousTotalCount) * 100 
+      : recentTotalCount > 0 ? 100 : 0;
+
+    // 해결률
+    const recentResolvedCount = recentComplaints.filter(c => c.is_confirmed).length;
+    const recentResolutionRate = recentTotalCount > 0 ? (recentResolvedCount / recentTotalCount) * 100 : 0;
+    
+    const previousResolvedCount = previousComplaints.filter(c => c.is_confirmed).length;
+    const previousResolutionRate = previousTotalCount > 0 ? (previousResolvedCount / previousTotalCount) * 100 : 0;
+    
+    const resolutionRateChange = previousResolutionRate > 0
+      ? ((recentResolutionRate - previousResolutionRate) / previousResolutionRate) * 100
+      : recentResolutionRate > 0 ? 100 : 0;
+
+    return {
+      totalDiagnoses: {
+        count: recentTotalCount,
+        changeRate: totalCountChange,
+      },
+      resolutionRate: {
+        rate: recentResolutionRate,
+        changeRate: resolutionRateChange,
+      },
+      echoCount: {
+        count: totalEchos,
+      },
+    };
+  }
+
+  async getAiDiagnosisSummary() {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    // 전체 데이터 집계
+    const totalCount = await this.complaintRepository.count();
+    const resolvedCount = await this.complaintRepository.count({ where: { is_confirmed: true } });
+    const pendingCount = totalCount - resolvedCount;
+
+    // 최근 24시간 내 변동 집계
+    const newTotal = await this.complaintRepository.count({
+      where: { timestamp: MoreThan(yesterday) },
+    });
+    const newResolved = await this.complaintRepository.count({
+      where: { is_confirmed: true, timestamp: MoreThan(yesterday) },
+    });
+    const newPending = newTotal - newResolved;
+
+    return {
+      total: {
+        count: totalCount,
+        change: newTotal,
+      },
+      resolved: {
+        count: resolvedCount,
+        change: newResolved,
+      },
+      pending: {
+        count: pendingCount,
+        change: newPending,
+      },
+    };
+  }
+
+  async getWeeklyDiagnoses() {
+    const today = new Date();
+    const sevenDaysAgo = new Date(today);
+    sevenDaysAgo.setDate(today.getDate() - 7);
+
+    const complaints = await this.complaintRepository.find({
+      where: {
+        timestamp: Between(sevenDaysAgo, today),
+      },
+      order: {
+        timestamp: 'ASC',
+      },
+    });
+
+    const weeklyData: { [key: string]: { total: number; resolved: number } } = {};
+
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(today);
+      date.setDate(today.getDate() - i);
+      const dateString = date.toISOString().split('T')[0]; // YYYY-MM-DD
+      weeklyData[dateString] = { total: 0, resolved: 0 };
+    }
+
+    complaints.forEach(complaint => {
+      if (complaint.timestamp) {
+        const dateString = complaint.timestamp.toISOString().split('T')[0];
+        if (weeklyData[dateString]) {
+          weeklyData[dateString].total += 1;
+          if (complaint.is_confirmed) {
+            weeklyData[dateString].resolved += 1;
+          }
+        }
+      }
+    });
+    
+    // 날짜 오름차순으로 정렬된 배열로 변환
+    return Object.entries(weeklyData)
+      .map(([date, data]) => ({ date, ...data }))
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  }
+
+  async getTagDistribution() {
+    const tagCounts = await this.complaintRepository
+      .createQueryBuilder('complaint')
+      .select('complaint.tag', 'tag')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('complaint.tag')
+      .orderBy('count', 'DESC')
+      .getRawMany();
+
+    return tagCounts.map(item => ({
+      tag: item.tag || '미분류',
+      count: parseInt(item.count, 10),
+    }));
+  }
+
+  async getHourlyComplaintDistribution() {
+    const hourlyCounts = await this.complaintRepository
+      .createQueryBuilder('complaint')
+      .select('EXTRACT(HOUR FROM complaint.timestamp)', 'hour')
+      .addSelect('COUNT(*)', 'count')
+      .where("complaint.timestamp IS NOT NULL")
+      .groupBy('hour')
+      .orderBy('hour', 'ASC')
+      .getRawMany();
+
+    const result = Array.from({ length: 24 }, (_, i) => ({ hour: i, count: 0 }));
+
+    hourlyCounts.forEach(item => {
+      // getRawMany() returns string values for numerical types from the DB
+      const hour = parseInt(item.hour, 10);
+      if (!isNaN(hour) && hour >= 0 && hour < 24) {
+        result[hour].count = parseInt(item.count, 10);
+      }
+    });
+
+    return result;
+  }
+}

--- a/src/seoulmeari-manage/seoulmeari-manage.module.ts
+++ b/src/seoulmeari-manage/seoulmeari-manage.module.ts
@@ -2,8 +2,9 @@ import { Module } from '@nestjs/common';
 import { AdminModule } from './admin/admin.module';
 import { AuthModule } from './auth/auth.module';
 import { BundlesModule } from './bundles/bundles.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 
 @Module({
-  imports: [AdminModule, AuthModule, BundlesModule],
+  imports: [AdminModule, AuthModule, BundlesModule, DashboardModule],
 })
 export class SeoulMeariManageModule {}


### PR DESCRIPTION


#### 1. 일반 대시보드 핵심 지표 요약

-   **용도**: 일반 대시보드 상단에 표시될 핵심 지표 (7일 기준 비교)
-   **Endpoint**: `GET /dashboard/summary`
-   **설명**: 지난 7일간의 데이터를 이전 7일과 비교하여 총 진단 건수, 해결률, 그리고 전체 메아리 수를 반환합니다.
-   **응답 예시 (JSON)**:
    ```json
    {
      "totalDiagnoses": {
        "count": 52,
        "changeRate": 15.5
      },
      "resolutionRate": {
        "rate": 88.4,
        "changeRate": -5.2
      },
      "echoCount": {
        "count": 1234
      }
    }
    ```

#### 2. AI 도시 진단 페이지 핵심 지표 요약

-   **용도**: AI 도시 진단 페이지 상단에 표시될 '총 건수', '처리 완료', '미처리' 지표
-   **Endpoint**: `GET /dashboard/ai-summary`
-   **설명**: 전체 기간의 데이터를 기준으로 총 진단 건수, 처리 완료 건수, 미처리 건수를 각각 집계하고, 최근 24시간 동안의 변동량을 함께 반환합니다.
-   **응답 예시 (JSON)**:
    ```json
    {
      "total": {
        "count": 2847,
        "change": 127
      },
      "resolved": {
        "count": 2735,
        "change": 98
      },
      "pending": {
        "count": 112,
        "change": 29
      }
    }
    ```

#### 3. 주간 진단 현황 (막대그래프용)

-   **용도**: 지난 7일간의 일별 진단 및 해결 건수를 보여주는 막대그래프
-   **Endpoint**: `GET /dashboard/weekly-diagnoses`
-   **설명**: 오늘을 포함하여 최근 7일 동안의 날짜별 총 진단 건수와 해결 건수를 배열로 반환합니다.
-   **응답 예시 (JSON)**:
    ```json
    [
      { "date": "2025-09-18", "total": 45, "resolved": 42 },
      { "date": "2025-09-19", "total": 42, "resolved": 38 },
      { "date": "2025-09-20", "total": 52, "resolved": 35 },
      { "date": "2025-09-21", "total": 48, "resolved": 60 },
      { "date": "2025-09-22", "total": 47, "resolved": 55 },
      { "date": "2025-09-23", "total": 42, "resolved": 30 },
      { "date": "2025-09-24", "total": 30, "resolved": 27 }
    ]
    ```

#### 4. 진단 유형별 분포 (원형 그래프용)

-   **용도**: '도로 파손', '쓰레기' 등 어떤 유형의 진단이 많은지 보여주는 원형 그래프
-   **Endpoint**: `GET /dashboard/tag-distribution`
-   **설명**: `complaints`의 `tag`를 기준으로 데이터를 그룹화하여, 각 태그별 진단 건수를 많은 순으로 정렬하여 반환합니다.
-   **응답 예시 (JSON)**:
    ```json
    [
      { "tag": "도로 파손", "count": 520 },
      { "tag": "불법 주정차", "count": 312 },
      { "tag": "쓰레기 무단 투기", "count": 155 },
      { "tag": "미분류", "count": 89 }
    ]
    ```

#### 5. 민원 시간별 분포 (꺾은선 그래프용)

-   **용도**: 하루 24시간 중 어느 시간대에 민원이 집중되는지 보여주는 꺾은선 그래프
-   **Endpoint**: `GET /dashboard/hourly-complaint-distribution`
-   **설명**: 0시부터 23시까지 각 시간대에 접수된 민원의 수를 집계하여 시간순으로 정렬된 배열로 반환합니다.
-   **응답 예시 (JSON)**:
    ```json
    [
      { "hour": 0, "count": 120 },
      { "hour": 1, "count": 95 },
      { "hour": 2, "count": 78 },
      { "hour": 23, "count": 150 }
    ]
    ```